### PR TITLE
Fix Internal Server Error by correcting Next.js configuration

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,3 +7,5 @@ const nextConfig = {
     ignoreDuringBuilds: true,
   },
 }
+
+export default nextConfig


### PR DESCRIPTION
- Resolved application-wide Internal Server Errors by adding the missing default export in `next.config.mjs`.
- Updated project `settings.json` to ensure consistent development environment configuration.

[v0 Session](https://v0.app/chat/ueP4Q1eGOPn)