### PR TITLE
Resolve Internal Server Errors caused by configuration issues

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,9 +3,6 @@ const nextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
 }
 
 export default nextConfig


### PR DESCRIPTION
- Fixed a configuration issue in Next.js that was triggering Internal Server Errors (500) and preventing the application from loading.

[v0 Session](https://v0.app/chat/ueP4Q1eGOPn)